### PR TITLE
Check if a stream exists before stopping it when hiding webcam element

### DIFF
--- a/src/mirror.js
+++ b/src/mirror.js
@@ -38,7 +38,9 @@ function hideWebcamElement() {
             console.log("removing webcam container");
             var vid = videoContainer.children[0];
             var stream = vid.srcObject;
-            stream.getTracks()[0].stop();
+            if (stream) {
+                stream.getTracks()[0].stop();
+            }
             vid.src = "";
             videoContainer.parentNode.removeChild(videoContainer);
         }


### PR DESCRIPTION
I discovered that the video stream could be `null` if the user has disabled their webcam, which prevents the video container from being removed. 